### PR TITLE
Support for multiple media objects (fixes #11)

### DIFF
--- a/generate_weeknotes.rb
+++ b/generate_weeknotes.rb
@@ -95,7 +95,8 @@ unless input_settings["twitter"].nil?
     config.access_token_secret = input_settings["twitter"]["oauth_secret"]
   end
   settings["tags"].each do |tag|
-    twitter_client.search("##{tag}", :count => 100, :result_type => "recent").each do |tweet|
+    twitter_client.search("##{tag}", :count => 100, :result_type => "recent").each do |result|
+      tweet = twitter_client.status(result)
       if tweet.created_at >= start_of_last_week && tweet.created_at <= end_of_last_week && !tweet.retweet?
         if tweet.user.following? || tweet.user.id == input_settings["twitter"]["id"]
           # It's a tweet in the past week containing "#weeknotes",


### PR DESCRIPTION
While it appears that Twitter::REST::Client#search will only ever return Twitter::Tweet objects with a single media entry, calling Twitter::REST::Client#status with the search result returns a Twitter::Tweet that includes all media entries.

I don't have a configuration to test this with here, but I've added a Gist demonstrating the fix at https://gist.github.com/brett-lempereur/7dc68961bc2a20de7be9.