### PR TITLE
Make the link to all issues more prominent

### DIFF
--- a/config-example-wordpress.yaml
+++ b/config-example-wordpress.yaml
@@ -85,4 +85,5 @@ output:
     issues: 
       <h3>Somebody Should</h3>
       <p>The DoES Liverpool to-do list is stored in the <a href='https://github.com/DoESLiverpool/somebody-should/issues'>issues of our Somebody Should repository</a> on github. Head over there if there's something you'd like to report, or if you want to help out fixing things.</p>
+      <p><ul><li><a href='https://github.com/DoESLiverpool/somebody-should/issues'>See all the issues…</a></li></ul></p>
 


### PR DESCRIPTION
From a comment from a new attendee to DoES that where to go to see the whole issue list was not obvious (they couldn't find it). So I've added a clearer *go here* link inside the Somebody Should area.